### PR TITLE
add templates for local ensemble observer and solver

### DIFF
--- a/local_ensemble_da_observer.yaml.j2
+++ b/local_ensemble_da_observer.yaml.j2
@@ -1,0 +1,192 @@
+# Set the model component to be used in later configuration
+{% set model_component = model_component|default('model_component') %}
+
+geometry:
+{% filter indent(width=2) %}
+{% set geometry_background_file = geometry_background_file|default(model_component ~ 'geometry_background', true) ~ '.yaml.j2' %}
+{% include geometry_background_file %}
+{% endfilter %}
+
+time window:
+  begin: '{{window_begin}}'
+  length: '{{window_length}}'
+  bound to include: '{{ bound_to_include | default("begin", true) }}'
+
+increment variables: {{increment_variables}}
+
+background:
+{% filter indent(width=2) %}
+{% set background_ensemble_file = background_ensemble_file|default(model_component ~ 'background_ensemble', true) ~ '.yaml.j2' %}
+{% include background_ensemble_file %}
+{% endfilter %}
+
+observations:
+  observers:
+{% for observation_from_jcb in observations %}
+{% if use_observer(observation_from_jcb) %}
+{% filter indent(width=2) %}
+{% include observation_from_jcb + '.yaml.j2' %}
+{% endfilter %}
+{% endif %}
+{% endfor %}
+
+
+local ensemble DA:
+  solver: {{local_ensemble_da_solver}}
+  use linear observer: {{use_linear_observer | default(true) }}
+{% if local_ensemble_da_solver == 'GETKF' %}
+  vertical localization:
+    fraction of retained variance: {{ vl_fraction_of_retained_variance | default(1.0, true) }}
+    lengthscale: {{vl_lengthscale}}
+    lengthscale units: {{vl_lengthscale_units}}
+    write eigen vectors: {{ vl_write_eigen_vectors | default(false, true) }}
+    read eigen vectors: {{ vl_read_eigen_vectors | default(false, true) }}
+{% endif %}
+  inflation:
+    rtps: {{inflation_rtps}}
+    rtpp: {{inflation_rtpp}}
+    mult: {{inflation_mult}}
+
+# Set the default values for all these driver things:
+{% set driver_update_obs_config_with_geometry_info = driver_update_obs_config_with_geometry_info | default(false) %}
+{% set driver_do_test_prints = driver_do_test_prints | default(true) %}
+{% set driver_read_HX_from_disk = driver_read_HX_from_disk | default(false) %}
+{% set driver_run_as_observer_only = driver_run_as_observer_only | default(true) %}
+{% set driver_save_posterior_mean = driver_save_posterior_mean | default(false) %}
+{% set driver_save_posterior_ensemble = driver_save_posterior_ensemble | default(false) %}
+{% set driver_save_prior_mean = driver_save_prior_mean | default(false) %}
+{% set driver_save_posterior_mean_increment = driver_save_posterior_mean_increment | default(false) %}
+{% set driver_save_posterior_ensemble_increments = driver_save_posterior_ensemble_increments | default(false) %}
+{% set driver_save_prior_variance = driver_save_prior_variance | default(false) %}
+{% set driver_save_posterior_variance = driver_save_posterior_variance | default(false) %}
+{% set driver_do_posterior_observer = driver_do_posterior_observer | default(false) %}
+{% set driver_use_control_member = driver_use_control_member | default(false) %}
+
+driver:
+  update obs config with geometry info: {{ driver_update_obs_config_with_geometry_info }}
+  do test prints: {{ driver_do_test_prints }}
+  read HX from disk: {{ driver_read_HX_from_disk }}
+  run as observer only: {{ driver_run_as_observer_only }}
+  save posterior mean: {{ driver_save_posterior_mean }}
+  save posterior ensemble: {{ driver_save_posterior_ensemble }}
+  save prior mean: {{ driver_save_prior_mean }}
+  save posterior mean increment: {{ driver_save_posterior_mean_increment }}
+  save posterior ensemble increments: {{ driver_save_posterior_ensemble_increments }}
+  save prior variance: {{ driver_save_prior_variance }}
+  save posterior variance: {{ driver_save_posterior_variance }}
+  do posterior observer: {{ driver_do_posterior_observer }}
+  use control member: {{ driver_use_control_member }}
+
+# The choice of output configurations below has to consistent with choices that are made in the
+# driver so there are lots of if statements. Don't be surprised if you find yourself here trying to
+# understand what is going on! Have a look in oops/src/oops/runs/LocalEnsembleDA.h to see what's
+# what. Note that some things are nested under output and some things given a separate output
+# section.
+
+# The below shows more cleanly the possible choices given the driver config
+
+#     control member:              # driver_use_control_member: True
+
+#     output:                      # driver_save_posterior_mean or driver_save_posterior_ensemble
+#       ensemble mean output:      # driver_save_posterior_mean: True
+#       ensemble members output:   # driver_save_posterior_ensemble: True
+
+#     output mean prior:           # driver_save_prior_mean: True
+#     output increment:            # driver_save_posterior_mean_increment: True
+#     output ensemble increments:  # driver_save_posterior_ensemble_increments: True
+#     output variance prior:       # driver_save_prior_variance: True
+#     output variance posterior:   # driver_save_posterior_variance: True
+
+# In jinja2 a statement resembling \{\% if something \%\} results in the the following:
+#
+#  If 'something' key is not present in the templates dictionary do nothing
+#  If 'something' key is present in the templates dictionary follow the Python truthiness rules
+#  on the value. So if for example the the value is an empty dictionary then it evaluates to False
+
+# control member
+# --------------
+{% if driver_use_control_member %}
+control member:
+{% filter indent(width=2) %}
+{% set control_member_file = control_member_file|default(model_component ~ 'control_member', true) ~ '.yaml.j2' %}
+{% include control_member_file %}
+{% endfilter %}
+{% endif %}
+
+# output
+# ------
+{% if driver_save_posterior_mean or driver_save_posterior_ensemble %}
+output:
+{% filter indent(width=2) %}
+{% set posterior_output_file = posterior_output_file|default(model_component ~ 'posterior_output', true) ~ '.yaml.j2' %}
+{% include posterior_output_file %}
+{% endfilter %}
+{% endif %}
+
+# output mean prior
+# -----------------
+{% if driver_save_prior_mean %}
+output mean prior:
+{% filter indent(width=2) %}
+{% set output_mean_prior_file = output_mean_prior_file|default(model_component ~ 'output_mean_prior', true) ~ '.yaml.j2' %}
+{% include output_mean_prior_file %}
+{% endfilter %}
+{% endif %}
+
+# output increment
+# ----------------
+{% if driver_save_posterior_mean_increment %}
+output increment:
+{% filter indent(width=2) %}
+{% set output_increment_file = output_increment_file|default(model_component ~ 'output_increment', true) ~ '.yaml.j2' %}
+{% include output_increment_file %}
+{% endfilter %}
+{% endif %}
+
+# output ensemble increments
+# --------------------------
+{% if driver_save_posterior_ensemble_increments %}
+output ensemble increments:
+{% filter indent(width=2) %}
+{% set output_ensemble_increments_file = output_ensemble_increments_file|default(model_component ~ 'output_ensemble_increments', true) ~ '.yaml.j2' %}
+{% include output_ensemble_increments_file %}
+{% endfilter %}
+{% endif %}
+
+# output variance prior
+# ---------------------
+{% if driver_save_prior_variance %}
+output variance prior:
+{% filter indent(width=2) %}
+{% set output_variance_prior_file = output_variance_prior_file|default(model_component ~ 'output_variance_prior', true) ~ '.yaml.j2' %}
+{% include output_variance_prior_file %}
+{% endfilter %}
+{% endif %}
+
+# output variance posterior
+# -------------------------
+{% if driver_save_posterior_variance %}
+output variance posterior:
+{% filter indent(width=2) %}
+{% set output_variance_posterior_file = output_variance_posterior_file|default(model_component ~ 'output_variance_posterior', true) ~ '.yaml.j2' %}
+{% include output_variance_posterior_file %}
+{% endfilter %}
+{% endif %}
+
+# Optionally test the application
+{% if test_reference_filename is defined %}
+test:
+  reference filename: {{test_reference_filename}}
+{% if test_output_filename is defined %}
+  test output filename: {{test_output_filename}}
+{% endif %}
+{% if log_output_filename is defined %}
+  log output filename: {{log_output_filename}}
+{% endif %}
+{% if mpi_pattern is defined %}
+  mpi pattern: {{mpi_pattern}}
+{% endif %}
+  float relative tolerance: {{test_float_relative_tolerance | default(1.0e-6, true)}}
+  float absolute tolerance: {{test_float_absolute_tolerance | default(0.0, true) }}
+  integer tolerance: {{test_integer_tolerance | default(0, true) }}
+{% endif %}

--- a/local_ensemble_da_solver.yaml.j2
+++ b/local_ensemble_da_solver.yaml.j2
@@ -1,0 +1,192 @@
+# Set the model component to be used in later configuration
+{% set model_component = model_component|default('model_component') %}
+
+geometry:
+{% filter indent(width=2) %}
+{% set geometry_background_file = geometry_background_file|default(model_component ~ 'geometry_background', true) ~ '.yaml.j2' %}
+{% include geometry_background_file %}
+{% endfilter %}
+
+time window:
+  begin: '{{window_begin}}'
+  length: '{{window_length}}'
+  bound to include: '{{ bound_to_include | default("begin", true) }}'
+
+increment variables: {{increment_variables}}
+
+background:
+{% filter indent(width=2) %}
+{% set background_ensemble_file = background_ensemble_file|default(model_component ~ 'background_ensemble', true) ~ '.yaml.j2' %}
+{% include background_ensemble_file %}
+{% endfilter %}
+
+observations:
+  observers:
+{% for observation_from_jcb in observations %}
+{% if use_observer(observation_from_jcb) %}
+{% filter indent(width=2) %}
+{% include observation_from_jcb + '.yaml.j2' %}
+{% endfilter %}
+{% endif %}
+{% endfor %}
+
+
+local ensemble DA:
+  solver: {{local_ensemble_da_solver}}
+  use linear observer: {{use_linear_observer | default(false) }}
+{% if local_ensemble_da_solver == 'GETKF' %}
+  vertical localization:
+    fraction of retained variance: {{ vl_fraction_of_retained_variance | default(1.0, true) }}
+    lengthscale: {{vl_lengthscale}}
+    lengthscale units: {{vl_lengthscale_units}}
+    write eigen vectors: {{ vl_write_eigen_vectors | default(false, true) }}
+    read eigen vectors: {{ vl_read_eigen_vectors | default(false, true) }}
+{% endif %}
+  inflation:
+    rtps: {{inflation_rtps}}
+    rtpp: {{inflation_rtpp}}
+    mult: {{inflation_mult}}
+
+# Set the default values for all these driver things:
+{% set driver_update_obs_config_with_geometry_info = driver_update_obs_config_with_geometry_info | default(true) %}
+{% set driver_do_test_prints = driver_do_test_prints | default(true) %}
+{% set driver_read_HX_from_disk = driver_read_HX_from_disk | default(true) %}
+{% set driver_run_as_observer_only = driver_run_as_observer_only | default(false) %}
+{% set driver_save_posterior_mean = driver_save_posterior_mean | default(false) %}
+{% set driver_save_posterior_ensemble = driver_save_posterior_ensemble | default(true) %}
+{% set driver_save_prior_mean = driver_save_prior_mean | default(false) %}
+{% set driver_save_posterior_mean_increment = driver_save_posterior_mean_increment | default(false) %}
+{% set driver_save_posterior_ensemble_increments = driver_save_posterior_ensemble_increments | default(true) %}
+{% set driver_save_prior_variance = driver_save_prior_variance | default(false) %}
+{% set driver_save_posterior_variance = driver_save_posterior_variance | default(false) %}
+{% set driver_do_posterior_observer = driver_do_posterior_observer | default(false) %}
+{% set driver_use_control_member = driver_use_control_member | default(false) %}
+
+driver:
+  update obs config with geometry info: {{ driver_update_obs_config_with_geometry_info }}
+  do test prints: {{ driver_do_test_prints }}
+  read HX from disk: {{ driver_read_HX_from_disk }}
+  run as observer only: {{ driver_run_as_observer_only }}
+  save posterior mean: {{ driver_save_posterior_mean }}
+  save posterior ensemble: {{ driver_save_posterior_ensemble }}
+  save prior mean: {{ driver_save_prior_mean }}
+  save posterior mean increment: {{ driver_save_posterior_mean_increment }}
+  save posterior ensemble increments: {{ driver_save_posterior_ensemble_increments }}
+  save prior variance: {{ driver_save_prior_variance }}
+  save posterior variance: {{ driver_save_posterior_variance }}
+  do posterior observer: {{ driver_do_posterior_observer }}
+  use control member: {{ driver_use_control_member }}
+
+# The choice of output configurations below has to consistent with choices that are made in the
+# driver so there are lots of if statements. Don't be surprised if you find yourself here trying to
+# understand what is going on! Have a look in oops/src/oops/runs/LocalEnsembleDA.h to see what's
+# what. Note that some things are nested under output and some things given a separate output
+# section.
+
+# The below shows more cleanly the possible choices given the driver config
+
+#     control member:              # driver_use_control_member: True
+
+#     output:                      # driver_save_posterior_mean or driver_save_posterior_ensemble
+#       ensemble mean output:      # driver_save_posterior_mean: True
+#       ensemble members output:   # driver_save_posterior_ensemble: True
+
+#     output mean prior:           # driver_save_prior_mean: True
+#     output increment:            # driver_save_posterior_mean_increment: True
+#     output ensemble increments:  # driver_save_posterior_ensemble_increments: True
+#     output variance prior:       # driver_save_prior_variance: True
+#     output variance posterior:   # driver_save_posterior_variance: True
+
+# In jinja2 a statement resembling \{\% if something \%\} results in the the following:
+#
+#  If 'something' key is not present in the templates dictionary do nothing
+#  If 'something' key is present in the templates dictionary follow the Python truthiness rules
+#  on the value. So if for example the the value is an empty dictionary then it evaluates to False
+
+# control member
+# --------------
+{% if driver_use_control_member %}
+control member:
+{% filter indent(width=2) %}
+{% set control_member_file = control_member_file|default(model_component ~ 'control_member', true) ~ '.yaml.j2' %}
+{% include control_member_file %}
+{% endfilter %}
+{% endif %}
+
+# output
+# ------
+{% if driver_save_posterior_mean or driver_save_posterior_ensemble %}
+output:
+{% filter indent(width=2) %}
+{% set posterior_output_file = posterior_output_file|default(model_component ~ 'posterior_output', true) ~ '.yaml.j2' %}
+{% include posterior_output_file %}
+{% endfilter %}
+{% endif %}
+
+# output mean prior
+# -----------------
+{% if driver_save_prior_mean %}
+output mean prior:
+{% filter indent(width=2) %}
+{% set output_mean_prior_file = output_mean_prior_file|default(model_component ~ 'output_mean_prior', true) ~ '.yaml.j2' %}
+{% include output_mean_prior_file %}
+{% endfilter %}
+{% endif %}
+
+# output increment
+# ----------------
+{% if driver_save_posterior_mean_increment %}
+output increment:
+{% filter indent(width=2) %}
+{% set output_increment_file = output_increment_file|default(model_component ~ 'output_increment', true) ~ '.yaml.j2' %}
+{% include output_increment_file %}
+{% endfilter %}
+{% endif %}
+
+# output ensemble increments
+# --------------------------
+{% if driver_save_posterior_ensemble_increments %}
+output ensemble increments:
+{% filter indent(width=2) %}
+{% set output_ensemble_increments_file = output_ensemble_increments_file|default(model_component ~ 'output_ensemble_increments', true) ~ '.yaml.j2' %}
+{% include output_ensemble_increments_file %}
+{% endfilter %}
+{% endif %}
+
+# output variance prior
+# ---------------------
+{% if driver_save_prior_variance %}
+output variance prior:
+{% filter indent(width=2) %}
+{% set output_variance_prior_file = output_variance_prior_file|default(model_component ~ 'output_variance_prior', true) ~ '.yaml.j2' %}
+{% include output_variance_prior_file %}
+{% endfilter %}
+{% endif %}
+
+# output variance posterior
+# -------------------------
+{% if driver_save_posterior_variance %}
+output variance posterior:
+{% filter indent(width=2) %}
+{% set output_variance_posterior_file = output_variance_posterior_file|default(model_component ~ 'output_variance_posterior', true) ~ '.yaml.j2' %}
+{% include output_variance_posterior_file %}
+{% endfilter %}
+{% endif %}
+
+# Optionally test the application
+{% if test_reference_filename is defined %}
+test:
+  reference filename: {{test_reference_filename}}
+{% if test_output_filename is defined %}
+  test output filename: {{test_output_filename}}
+{% endif %}
+{% if log_output_filename is defined %}
+  log output filename: {{log_output_filename}}
+{% endif %}
+{% if mpi_pattern is defined %}
+  mpi pattern: {{mpi_pattern}}
+{% endif %}
+  float relative tolerance: {{test_float_relative_tolerance | default(1.0e-6, true)}}
+  float absolute tolerance: {{test_float_absolute_tolerance | default(0.0, true) }}
+  integer tolerance: {{test_integer_tolerance | default(0, true) }}
+{% endif %}


### PR DESCRIPTION
This PR adds two local ensemble DA templates
- `local_ensemble_da_observer.yaml.j2`
- `local_ensemble_da_solver.yaml.j2`

The first runs the lgetkf in observer mode.  The second runs the lgetkf in solver mode.  

Resolves #3