### PR TITLE
change latlon to structured grid

### DIFF
--- a/3dfgat.yaml.j2
+++ b/3dfgat.yaml.j2
@@ -69,7 +69,7 @@ final:
 
 # Optional final fields to write out
 {% if final_increment_to_latlon_file is defined %}
-  increment to latlon:
+  increment to structured grid:
 {% filter indent(width=4) %}
 {% set final_increment_to_latlon_file = final_increment_to_latlon_file ~ '.yaml.j2' %}
 {% include final_increment_to_latlon_file %}
@@ -77,7 +77,7 @@ final:
 {% endif %}
 
 {% if final_analysis_to_latlon_file is defined %}
-  analysis to latlon:
+  analysis to structured grid:
 {% filter indent(width=4) %}
 {% set final_analysis_to_latlon_file = final_analysis_to_latlon_file ~ '.yaml.j2' %}
 {% include final_analysis_to_latlon_file %}

--- a/3dvar.yaml.j2
+++ b/3dvar.yaml.j2
@@ -63,7 +63,7 @@ final:
 
 # Optional final fields to write out
 {% if final_increment_to_latlon_file is defined %}
-  increment to latlon:
+  increment to structured grid:
 {% filter indent(width=4) %}
 {% set final_increment_to_latlon_file = final_increment_to_latlon_file ~ '.yaml.j2' %}
 {% include final_increment_to_latlon_file %}
@@ -71,7 +71,7 @@ final:
 {% endif %}
 
 {% if final_analysis_to_latlon_file is defined %}
-  analysis to latlon:
+  analysis to structured grid:
 {% filter indent(width=4) %}
 {% set final_analysis_to_latlon_file = final_analysis_to_latlon_file ~ '.yaml.j2' %}
 {% include final_analysis_to_latlon_file %}


### PR DESCRIPTION
OOPS changed from 'latlon' to 'structured grid' to be more generic to handle Gaussian grids. This updates the JCB 3DVar and 3DFGAT YAML templates to reflect this change.