### PR TITLE
Turn off jb eval

### DIFF
--- a/3dfgat.yaml.j2
+++ b/3dfgat.yaml.j2
@@ -5,6 +5,8 @@ cost function:
 
   cost type: 3D-FGAT
 
+  jb evaluation: false
+
   time window:
     begin: '{{window_begin}}'
     length: '{{window_length}}'
@@ -118,3 +120,6 @@ test:
   float absolute tolerance: {{test_float_absolute_tolerance | default(0.0, true) }}
   integer tolerance: {{test_integer_tolerance | default(0, true) }}
 {% endif %}
+
+# Turn off the final J eval
+final j evaluation: false

--- a/3dfgat.yaml.j2
+++ b/3dfgat.yaml.j2
@@ -5,7 +5,7 @@ cost function:
 
   cost type: 3D-FGAT
 
-  jb evaluation: false
+  jb evaluation: {{ jb_evaluation | default(true) }}
 
   time window:
     begin: '{{window_begin}}'
@@ -122,4 +122,4 @@ test:
 {% endif %}
 
 # Turn off the final J eval
-final j evaluation: false
+final j evaluation: {{ final_j_evaluation | default(true) }}

--- a/3dfgat.yaml.j2
+++ b/3dfgat.yaml.j2
@@ -5,7 +5,7 @@ cost function:
 
   cost type: 3D-FGAT
 
-  jb evaluation: {{ jb_evaluation | default(true) }}
+  jb evaluation: {{ jb_evaluation | default(false) }}
 
   time window:
     begin: '{{window_begin}}'
@@ -122,4 +122,4 @@ test:
 {% endif %}
 
 # Turn off the final J eval
-final j evaluation: {{ final_j_evaluation | default(true) }}
+final j evaluation: {{ final_j_evaluation | default(false) }}

--- a/3dvar.yaml.j2
+++ b/3dvar.yaml.j2
@@ -5,7 +5,7 @@ cost function:
 
   cost type: 3D-Var
 
-  jb evaluation: {{ jb_evaluation | default(true) }}
+  jb evaluation: {{ jb_evaluation | default(false) }}
 
   time window:
     begin: '{{window_begin}}'
@@ -116,4 +116,4 @@ test:
 {% endif %}
 
 # Turn off the final J eval
-final j evaluation: {{ final_j_evaluation | default(true) }}
+final j evaluation: {{ final_j_evaluation | default(false) }}

--- a/3dvar.yaml.j2
+++ b/3dvar.yaml.j2
@@ -5,6 +5,8 @@ cost function:
 
   cost type: 3D-Var
 
+  jb evaluation: false
+
   time window:
     begin: '{{window_begin}}'
     length: '{{window_length}}'
@@ -112,3 +114,6 @@ test:
   float absolute tolerance: {{test_float_absolute_tolerance | default(0.0, true) }}
   integer tolerance: {{test_integer_tolerance | default(0, true) }}
 {% endif %}
+
+# Turn off the final J eval
+final j evaluation: false

--- a/3dvar.yaml.j2
+++ b/3dvar.yaml.j2
@@ -5,7 +5,7 @@ cost function:
 
   cost type: 3D-Var
 
-  jb evaluation: false
+  jb evaluation: {{ jb_evaluation | default(true) }}
 
   time window:
     begin: '{{window_begin}}'
@@ -116,4 +116,4 @@ test:
 {% endif %}
 
 # Turn off the final J eval
-final j evaluation: false
+final j evaluation: {{ final_j_evaluation | default(true) }}


### PR DESCRIPTION
I'm not 100% sure this fixes the memory issue on MSU HPC, but, while I was working on other things, I turned off the jb eval out of impatience to gain ~5+mn of runtime. I also noticed that the memory footprint is down to ~0.8TB for the 3DVARFGAT.
I'm testing with more iterations right now.