### PR TITLE
obspaces to obsspaces for anlstat

### DIFF
--- a/anlstat.yaml.j2
+++ b/anlstat.yaml.j2
@@ -4,7 +4,7 @@ time window:
   bound to include: '{{ bound_to_include | default("begin", true) }}'
 
 obs spaces:
-{% for obspace in obspaces %}
+{% for obspace in obsspaces %}
 {% filter indent(width=2) %}
 {% include obspace + '_template.yaml.j2' %}
 {% endfilter %}


### PR DESCRIPTION
Fix a typo (well rather just rename a key) from `obspaces` to `obsspaces`