### PR TITLE
Add jinja2 variable check to local ensemble da for snow LETKF

### DIFF
--- a/local_ensemble_da.yaml.j2
+++ b/local_ensemble_da.yaml.j2
@@ -12,7 +12,9 @@ time window:
   length: '{{window_length}}'
   bound to include: '{{ bound_to_include | default("begin", true) }}'
 
+{%- if increment_variables is defined %}
 increment variables: {{increment_variables}}
+{%- endif %}
 
 background:
 {% filter indent(width=2) %}


### PR DESCRIPTION
- Based on the sample script for snow LETKF in `fv3-jedi` ([letkf_snow.yaml](https://github.com/JCSDA/fv3-jedi/blob/develop/test/testinput/letkf_snow.yaml)), the definition of `increment variables` is not necessary at least for snow LETKF.
- Therefore, the jinja2 if-statement checking the variable is added to the line. If the variable is defined in the jcb base yaml file, it will be activated in the output yaml file.
- This was tested in the UFS land-DA workflow ([PR#205](https://github.com/ufs-community/land-DA_workflow/pull/205)).