### PR TITLE
add Deterministic to local ensemble DA solver name

### DIFF
--- a/local_ensemble_da.yaml.j2
+++ b/local_ensemble_da.yaml.j2
@@ -33,7 +33,7 @@ observations:
 
 local ensemble DA:
   solver: {{local_ensemble_da_solver}}
-{% if local_ensemble_da_solver == 'GETKF' %}
+{% if local_ensemble_da_solver == 'Deterministic GETKF' %}
   vertical localization:
     fraction of retained variance: {{ vl_fraction_of_retained_variance | default(1.0, true) }}
     lengthscale: {{vl_lengthscale}}

--- a/local_ensemble_da_observer.yaml.j2
+++ b/local_ensemble_da_observer.yaml.j2
@@ -34,7 +34,7 @@ observations:
 local ensemble DA:
   solver: {{local_ensemble_da_solver}}
   use linear observer: {{use_linear_observer | default(true) }}
-{% if local_ensemble_da_solver == 'GETKF' %}
+{% if local_ensemble_da_solver == 'Deterministic GETKF' %}
   vertical localization:
     fraction of retained variance: {{ vl_fraction_of_retained_variance | default(1.0, true) }}
     lengthscale: {{vl_lengthscale}}

--- a/local_ensemble_da_solver.yaml.j2
+++ b/local_ensemble_da_solver.yaml.j2
@@ -34,7 +34,7 @@ observations:
 local ensemble DA:
   solver: {{local_ensemble_da_solver}}
   use linear observer: {{use_linear_observer | default(false) }}
-{% if local_ensemble_da_solver == 'GETKF' %}
+{% if local_ensemble_da_solver == 'Deterministic GETKF' %}
   vertical localization:
     fraction of retained variance: {{ vl_fraction_of_retained_variance | default(1.0, true) }}
     lengthscale: {{vl_lengthscale}}


### PR DESCRIPTION
As described in GDASApp issue [#1756](https://github.com/NOAA-EMC/GDASApp/issues/1756) updates in oops and fv3-jedi require the addition of the string _Deterministic_ or _Stochastic_ to local ensemble DA solver names.

This PR adds _Deterministic_ to the following jcb-algorithm yaml templates

```
local_ensemble_da.yaml.j2
local_ensemble_da_observer.yaml.j2
local_ensemble_da_solver.yaml.j2
```
Resolves #14