### PR TITLE
Add vader custom cookbook option

### DIFF
--- a/3dfgat.yaml.j2
+++ b/3dfgat.yaml.j2
@@ -40,6 +40,13 @@ cost function:
 
   observations:
     obs perturbations: {{ obs_perturbations | default(false, true) }}
+{% if vader_custom_cookbook_file is defined %}
+    get values:
+{% filter indent(width=6) %}
+{% set vader_custom_cookbook_file = vader_custom_cookbook_file ~ '.yaml.j2' %}
+{% include vader_custom_cookbook_file %}
+{% endfilter %}
+{% endif %}
     observers:
 {% for observation_from_jcb in observations %}
 {% if use_observer(observation_from_jcb) %}

--- a/3dvar.yaml.j2
+++ b/3dvar.yaml.j2
@@ -34,6 +34,13 @@ cost function:
 
   observations:
     obs perturbations: {{ obs_perturbations | default(false, true) }}
+{% if vader_custom_cookbook_file is defined %}
+    get values:
+{% filter indent(width=6) %}
+{% set vader_custom_cookbook_file = vader_custom_cookbook_file ~ '.yaml.j2' %}
+{% include vader_custom_cookbook_file %}
+{% endfilter %}
+{% endif %}
     observers:
 {% for observation_from_jcb in observations %}
 {% if use_observer(observation_from_jcb) %}

--- a/hofx3d.yaml.j2
+++ b/hofx3d.yaml.j2
@@ -20,6 +20,13 @@ state:
 
 observations:
   obs perturbations: {{ obs_perturbations | default(false, true) }}
+{% if vader_custom_cookbook_file is defined %}
+  get values:
+{% filter indent(width=4) %}
+{% set vader_custom_cookbook_file = vader_custom_cookbook_file ~ '.yaml.j2' %}
+{% include vader_custom_cookbook_file %}
+{% endfilter %}
+{% endif %}
   observers:
 {% for observation_from_jcb in observations %}
 {% if use_observer(observation_from_jcb) %}

--- a/hofx4d.yaml.j2
+++ b/hofx4d.yaml.j2
@@ -27,6 +27,13 @@ model:
 
 observations:
   obs perturbations: {{ obs_perturbations | default(false, true) }}
+{% if vader_custom_cookbook_file is defined %}
+  get values:
+{% filter indent(width=4) %}
+{% set vader_custom_cookbook_file = vader_custom_cookbook_file ~ '.yaml.j2' %}
+{% include vader_custom_cookbook_file %}
+{% endfilter %}
+{% endif %}
   observers:
 {% for observation_from_jcb in observations %}
 {% if use_observer(observation_from_jcb) %}

--- a/local_ensemble_da.yaml.j2
+++ b/local_ensemble_da.yaml.j2
@@ -21,6 +21,13 @@ background:
 {% endfilter %}
 
 observations:
+{% if vader_custom_cookbook_file is defined %}
+  get values:
+{% filter indent(width=4) %}
+{% set vader_custom_cookbook_file = vader_custom_cookbook_file ~ '.yaml.j2' %}
+{% include vader_custom_cookbook_file %}
+{% endfilter %}
+{% endif %}
   observers:
 {% for observation_from_jcb in observations %}
 {% if use_observer(observation_from_jcb) %}

--- a/local_ensemble_da_observer.yaml.j2
+++ b/local_ensemble_da_observer.yaml.j2
@@ -27,7 +27,7 @@ observations:
 {% set vader_custom_cookbook_file = vader_custom_cookbook_file ~ '.yaml.j2' %}
 {% include vader_custom_cookbook_file %}
 {% endfilter %}
-{% endif %}:
+{% endif %}
   observers:
 {% for observation_from_jcb in observations %}
 {% if use_observer(observation_from_jcb) %}

--- a/local_ensemble_da_observer.yaml.j2
+++ b/local_ensemble_da_observer.yaml.j2
@@ -21,6 +21,13 @@ background:
 {% endfilter %}
 
 observations:
+{% if vader_custom_cookbook_file is defined %}
+  get values:
+{% filter indent(width=4) %}
+{% set vader_custom_cookbook_file = vader_custom_cookbook_file ~ '.yaml.j2' %}
+{% include vader_custom_cookbook_file %}
+{% endfilter %}
+{% endif %}:
   observers:
 {% for observation_from_jcb in observations %}
 {% if use_observer(observation_from_jcb) %}

--- a/local_ensemble_da_solver.yaml.j2
+++ b/local_ensemble_da_solver.yaml.j2
@@ -21,6 +21,13 @@ background:
 {% endfilter %}
 
 observations:
+{% if vader_custom_cookbook_file is defined %}
+  get values:
+{% filter indent(width=4) %}
+{% set vader_custom_cookbook_file = vader_custom_cookbook_file ~ '.yaml.j2' %}
+{% include vader_custom_cookbook_file %}
+{% endfilter %}
+{% endif %}
   observers:
 {% for observation_from_jcb in observations %}
 {% if use_observer(observation_from_jcb) %}


### PR DESCRIPTION
This PR adds the ability to add a vader custom cookbook. The final YAML will look something like:

```yaml
  observations:
    ...
    get values:
      variable change:
        variable change name: Model2GeoVaLs
        vader:
          recipe parameters:
          ...
        vader custom cookbook:
        ...
```

The custom cookbook would contain everything starting with "`variable change:`"

To use the cookbook, specify it in the jcb-configuration file
```yaml
vader_custom_cookbook_file: atmosphere_vader_custom_cookbook
```

And the cookbook goes in jcb-rdas/gdas as
`parm/jcb-rdas/model/atmosphere/atmosphere_vader_custom_cookbook.yaml.j2`